### PR TITLE
chore(build): remove JUnit 5 from main compile classpath

### DIFF
--- a/MotorPhPayrollApp/nbproject/project.properties
+++ b/MotorPhPayrollApp/nbproject/project.properties
@@ -41,7 +41,6 @@ file.reference.opencsv-5.10.jar=src/resources/opencsv-5.10.jar
 includes=**
 jar.compress=false
 javac.classpath=\
-    ${libs.junit_5.classpath}:\
     ${file.reference.jcalendar-1.4.jar}:\
     ${file.reference.mysql-connector-j-9.3.0.jar}:\
     ${file.reference.opencsv-5.10.jar}
@@ -96,7 +95,8 @@ run.modulepath=\
     ${javac.modulepath}
 run.test.classpath=\
     ${javac.test.classpath}:\
-    ${build.test.classes.dir}
+    ${build.test.classes.dir}:\
+    ${libs.junit_5.classpath}
 run.test.modulepath=\
     ${javac.test.modulepath}
 source.encoding=UTF-8


### PR DESCRIPTION
### Summary

- Deleted the `${libs.junit_5.classpath}` entry under `javac.classpath` in `project.properties`.

### Rationale

JUnit 5 is a test-only dependency and should not be included in the main compile classpath. This change ensures:
- Cleaner separation of test and production code
- Avoids unnecessary dependency bloat during normal compilation
